### PR TITLE
libgpg-error: Update 500-entware-archs.patch

### DIFF
--- a/libs/libgpg-error/patches/500-entware-archs.patch
+++ b/libs/libgpg-error/patches/500-entware-archs.patch
@@ -20,7 +20,7 @@
 +    {"mips-openwrt-linux-gnu", "mips-unknown-linux-gnu"},
  
      {"arm-unknown-linux-gnueabihf",  "arm-unknown-linux-gnueabi" },
-+    {"aarch64-openwrt-linux-gnu"  },
++    {"aarch64-openwrt-linux-gnu", "aarch64-unknown-linux-gnu" },
      {"armv7-unknown-linux-gnueabihf"  },
      {"armv5-unknown-linux-musleabi"   },
      {"armv6-unknown-linux-musleabihf" },


### PR DESCRIPTION
Compile tested: (aarch64, RT-AC86U, Asuswrt-Merlin)
Run tested: (aarch64, RT-AC86U, Asuswrt-Merlin)

See the problem with `cryptsetup` (`libgcrypt` version only).  This assertion happens inside the shared library, `libgpg-error`.  The file `posix-lock.c` is in `libgpg-error`.
```
# /opt/sbin/cryptsetup --version
cryptsetup 1.7.5
cryptsetup: posix-lock.c:137: get_lock_object: Assertion `!"sizeof lock obj"' failed.
Aborted
```
My pull request fixes this issue.  
The `openssl` version of `cryptsetup` is not affected.
